### PR TITLE
Skip resource compiler when attempting to transform binaries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildScan {
 
 group = "jaci.gradle"
 archivesBaseName = "EmbeddedTools"
-version = "2019.11.13" // YYYY.MM.DD(revision)
+version = "2020.12.23" // YYYY.MM.DD(revision)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/jaci/gradle/toolchains/ToolchainsPlugin.groovy
+++ b/src/main/groovy/jaci/gradle/toolchains/ToolchainsPlugin.groovy
@@ -88,6 +88,10 @@ class ToolchainsPlugin implements Plugin<Project> {
                             log.debug("Found transform: ${transform.languageName}")
                             log.debug("Requires tool: ${requiresTool}")
 
+                            if (requiresTool.equals(ToolType.WINDOW_RESOURCES_COMPILER)) {
+                                continue
+                            }
+
                             def searchResult = toolProvider.locateTool(requiresTool)
                             if (!searchResult.isAvailable()) {
                                 markUnavailable(log, bin, "Toolchain ${tc.name} cannot build ${bin.targetPlatform.name} (tool ${requiresTool} not found)", true, true, true)


### PR DESCRIPTION
Workaround, but best option we got for now